### PR TITLE
Add GitLab CI configuration with included templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+include:
+  - project: 'selfservice-bi-data-science/sfi/ci-templates'
+    ref: main
+    file: '/github-mirror-sync.yml'
+
+variables:
+  GITHUB_REPO: "InovaFiscaliza/SupportPackages"


### PR DESCRIPTION
Arquivo de configuração CI/CD que mescla o template "github-mirror-sync.yml do repo selfservice-bi-data-science/sfi/ci-templates. 

Este template sincroniza o repositório, tags e releases do github para o gitlab. 

Assim atendemos o requisito da SGI de manter os repositórios dos projetos do LITE também no Gitlab da Anatel